### PR TITLE
Fixed the rigidbody flying bug

### DIFF
--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -598,6 +598,8 @@ func grab():
 # Add that vector to the movement vector of the object to move it to the grabbing position, which
 # is smoothened by GrabSmoothing.
 	objectGrabbed.linear_velocity = vector * GrabSmoothing
+# setting the collision layer to 0 so it would not collide with player
+	objectGrabbed.set_collision_layer(0)
 # The spring arm's length that contains the grabbing position can be adjusted by the scroll wheel
 # and set the length of that spring arm to that scroll value.
 	scroll = lerp(scroll,scrollInput,ScrollSmoothing)
@@ -608,6 +610,8 @@ func release():
 	objectGrabbed.axis_lock_angular_x = false
 	objectGrabbed.axis_lock_angular_y = false
 	objectGrabbed.axis_lock_angular_z = false
+# setting the collision layer to 1 so after releasing the object it would collide with player again
+	objectGrabbed.set_collision_layer(1)
 # Remove the node from being excluded on the player's raycast and set object that is grabbed to
 # none.
 	$Head/Hand.remove_excluded_object(objectGrabbed)


### PR DESCRIPTION
If you stand on a rigidbody and grab it you can fly trough the map with it. So basically I just used the same method that can be found in Portal 2. You disable the rigidbody collision between itself and the player but keep collisions elsewhere.